### PR TITLE
[storage] Rename NVMf -> Nvme

### DIFF
--- a/pydpu/proto/v1/backend_nvme_tcp_pb2.py
+++ b/pydpu/proto/v1/backend_nvme_tcp_pb2.py
@@ -21,9 +21,10 @@ from google.api import field_behavior_pb2 as google_dot_api_dot_field__behavior_
 from google.protobuf import field_mask_pb2 as google_dot_protobuf_dot_field__mask__pb2
 import object_key_pb2 as object__key__pb2
 import opicommon_pb2 as opicommon__pb2
+import uuid_pb2 as uuid__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16\x62\x61\x63kend_nvme_tcp.proto\x12\x12opi_api.storage.v1\x1a\x17google/api/client.proto\x1a\x19google/api/resource.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a google/protobuf/field_mask.proto\x1a\x10object_key.proto\x1a\x0fopicommon.proto\"\x99\x03\n\x14NVMfRemoteController\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x35\n\x06trtype\x18\x02 \x01(\x0e\x32%.opi_api.storage.v1.NvmeTransportType\x12\x35\n\x06\x61\x64rfam\x18\x03 \x01(\x0e\x32%.opi_api.storage.v1.NvmeAddressFamily\x12\x0e\n\x06traddr\x18\x04 \x01(\t\x12\x0f\n\x07trsvcid\x18\x05 \x01(\x03\x12\x0e\n\x06subnqn\x18\x06 \x01(\t\x12\r\n\x05hdgst\x18\x07 \x01(\x08\x12\r\n\x05\x64\x64gst\x18\x08 \x01(\x08\x12\x34\n\tmultipath\x18\t \x01(\x0e\x32!.opi_api.storage.v1.NvmeMultipath\x12\x17\n\x0fio_queues_count\x18\n \x01(\x03\x12\x12\n\nqueue_size\x18\x0b \x01(\x03\x12\x0f\n\x07hostnqn\x18\x0c \x01(\t:B\xea\x41?\n+storage.opiproject.org/NVMfRemoteController\x12\x10volumes/{volume}\"\x97\x01\n!CreateNVMfRemoteControllerRequest\x12N\n\x17nv_mf_remote_controller\x18\x02 \x01(\x0b\x32(.opi_api.storage.v1.NVMfRemoteControllerB\x03\xe0\x41\x02\x12\"\n\x1anv_mf_remote_controller_id\x18\x03 \x01(\t\"y\n!DeleteNVMfRemoteControllerRequest\x12=\n\x04name\x18\x01 \x01(\tB/\xe0\x41\x02\xfa\x41)\n\'opi_api.storage.v1/NVMfRemoteController\x12\x15\n\rallow_missing\x18\x02 \x01(\x08\"\xb6\x01\n!UpdateNVMfRemoteControllerRequest\x12I\n\x17nv_mf_remote_controller\x18\x01 \x01(\x0b\x32(.opi_api.storage.v1.NVMfRemoteController\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12\x15\n\rallow_missing\x18\x03 \x01(\x08\"\x8a\x01\n ListNVMfRemoteControllersRequest\x12?\n\x06parent\x18\x01 \x01(\tB/\xe0\x41\x02\xfa\x41)\n\'opi_api.storage.v1/NVMfRemoteController\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"\x88\x01\n!ListNVMfRemoteControllersResponse\x12J\n\x18nv_mf_remote_controllers\x18\x01 \x03(\x0b\x32(.opi_api.storage.v1.NVMfRemoteController\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"_\n\x1eGetNVMfRemoteControllerRequest\x12=\n\x04name\x18\x01 \x01(\tB/\xe0\x41\x02\xfa\x41)\n\'opi_api.storage.v1/NVMfRemoteController\"L\n NVMfRemoteControllerResetRequest\x12(\n\x02id\x18\x01 \x01(\x0b\x32\x1c.opi_api.common.v1.ObjectKey\"L\n NVMfRemoteControllerStatsRequest\x12(\n\x02id\x18\x01 \x01(\x0b\x32\x1c.opi_api.common.v1.ObjectKey\"S\n!NVMfRemoteControllerStatsResponse\x12.\n\x05stats\x18\x01 \x01(\x0b\x32\x1f.opi_api.storage.v1.VolumeStats*\xb4\x01\n\x11NvmeTransportType\x12#\n\x1fNVME_TRANSPORT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11NVME_TRANSPORT_FC\x10\x01\x12\x17\n\x13NVME_TRANSPORT_PCIE\x10\x02\x12\x17\n\x13NVME_TRANSPORT_RDMA\x10\x03\x12\x16\n\x12NVME_TRANSPORT_TCP\x10\x04\x12\x19\n\x15NVME_TRANSPORT_CUSTOM\x10\x05*\xa8\x01\n\x11NvmeAddressFamily\x12#\n\x1fNVME_ADDRESS_FAMILY_UNSPECIFIED\x10\x00\x12\x14\n\x10NVMF_ADRFAM_IPV4\x10\x01\x12\x14\n\x10NVMF_ADRFAM_IPV6\x10\x02\x12\x12\n\x0eNVMF_ADRFAM_IB\x10\x03\x12\x12\n\x0eNVMF_ADRFAM_FC\x10\x04\x12\x1a\n\x16NVMF_ADRFAM_INTRA_HOST\x10\x05*\x86\x01\n\rNvmeMultipath\x12\x1e\n\x1aNVME_MULTIPATH_UNSPECIFIED\x10\x00\x12\x1a\n\x16NVME_MULTIPATH_DISABLE\x10\x01\x12\x1b\n\x17NVME_MULTIPATH_FAILOVER\x10\x02\x12\x1c\n\x18NVME_MULTIPATH_MULTIPATH\x10\x03\x32\xf1\t\n\x1bNVMfRemoteControllerService\x12\xe0\x01\n\x1a\x43reateNVMfRemoteController\x12\x35.opi_api.storage.v1.CreateNVMfRemoteControllerRequest\x1a(.opi_api.storage.v1.NVMfRemoteController\"a\x82\xd3\xe4\x93\x02&\"\x0b/v1/volumes:\x17nv_mf_remote_controller\xda\x41\x32nv_mf_remote_controller,nv_mf_remote_controller_id\x12\x9d\x01\n\x1a\x44\x65leteNVMfRemoteController\x12\x35.opi_api.storage.v1.DeleteNVMfRemoteControllerRequest\x1a\x16.google.protobuf.Empty\"0\x82\xd3\xe4\x93\x02#*!/v1/{name=subsystems}/{subsystem}\xda\x41\x04name\x12\xf3\x01\n\x1aUpdateNVMfRemoteController\x12\x35.opi_api.storage.v1.UpdateNVMfRemoteControllerRequest\x1a(.opi_api.storage.v1.NVMfRemoteController\"t\x82\xd3\xe4\x93\x02H2-/v1/{nv_mf_remote_controller.name=subsystems}:\x17nv_mf_remote_controller\xda\x41#nv_mf_remote_controller,update_mask\x12\xb2\x01\n\x19ListNVMfRemoteControllers\x12\x34.opi_api.storage.v1.ListNVMfRemoteControllersRequest\x1a\x35.opi_api.storage.v1.ListNVMfRemoteControllersResponse\"(\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/{parent=subsystems}\xda\x41\x06parent\x12\xa9\x01\n\x17GetNVMfRemoteController\x12\x32.opi_api.storage.v1.GetNVMfRemoteControllerRequest\x1a(.opi_api.storage.v1.NVMfRemoteController\"0\x82\xd3\xe4\x93\x02#\x12!/v1/{name=subsystems}/{subsystem}\xda\x41\x04name\x12k\n\x19NVMfRemoteControllerReset\x12\x34.opi_api.storage.v1.NVMfRemoteControllerResetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x8a\x01\n\x19NVMfRemoteControllerStats\x12\x34.opi_api.storage.v1.NVMfRemoteControllerStatsRequest\x1a\x35.opi_api.storage.v1.NVMfRemoteControllerStatsResponse\"\x00\x42\x62\n\x12opi_api.storage.v1B\x13\x42\x61\x63kendNvmeTcpProtoP\x01Z5github.com/opiproject/opi-api/storage/v1alpha1/gen/gob\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16\x62\x61\x63kend_nvme_tcp.proto\x12\x12opi_api.storage.v1\x1a\x17google/api/client.proto\x1a\x19google/api/resource.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a google/protobuf/field_mask.proto\x1a\x10object_key.proto\x1a\x0fopicommon.proto\x1a\nuuid.proto\"\xe9\x01\n\x14NvmeRemoteController\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05hdgst\x18\x02 \x01(\x08\x12\r\n\x05\x64\x64gst\x18\x03 \x01(\x08\x12\x34\n\tmultipath\x18\x04 \x01(\x0e\x32!.opi_api.storage.v1.NvmeMultipath\x12\x17\n\x0fio_queues_count\x18\x05 \x01(\x03\x12\x12\n\nqueue_size\x18\x06 \x01(\x03:B\xea\x41?\n+storage.opiproject.org/NvmeRemoteController\x12\x10volumes/{volume}\"\xe4\x02\n\x08NvmePath\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x33\n\rcontroller_id\x18\x02 \x01(\x0b\x32\x1c.opi_api.common.v1.ObjectKey\x12\x35\n\x06trtype\x18\x03 \x01(\x0e\x32%.opi_api.storage.v1.NvmeTransportType\x12\x35\n\x06\x61\x64rfam\x18\x04 \x01(\x0e\x32%.opi_api.storage.v1.NvmeAddressFamily\x12\x0e\n\x06traddr\x18\x05 \x01(\t\x12\x0f\n\x07trsvcid\x18\x06 \x01(\x03\x12\x0e\n\x06subnqn\x18\x07 \x01(\t\x12\x15\n\rsource_traddr\x18\x08 \x01(\t\x12\x16\n\x0esource_trsvcid\x18\t \x01(\x03\x12\x0f\n\x07hostnqn\x18\n \x01(\t:6\xea\x41\x33\n\x1fstorage.opiproject.org/NvmePath\x12\x10volumes/{volume}\"\xee\x01\n\x13NvmeRemoteNamespace\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x33\n\rcontroller_id\x18\x02 \x01(\x0b\x32\x1c.opi_api.common.v1.ObjectKey\x12\x0c\n\x04nsid\x18\x03 \x01(\x05\x12\r\n\x05nguid\x18\x04 \x01(\t\x12\r\n\x05\x65ui64\x18\x05 \x01(\x03\x12%\n\x04uuid\x18\x06 \x01(\x0b\x32\x17.opi_api.common.v1.Uuid:A\xea\x41>\n*storage.opiproject.org/NvmeRemoteNamespace\x12\x10volumes/{volume}\"\x95\x01\n!CreateNvmeRemoteControllerRequest\x12M\n\x16nvme_remote_controller\x18\x02 \x01(\x0b\x32(.opi_api.storage.v1.NvmeRemoteControllerB\x03\xe0\x41\x02\x12!\n\x19nvme_remote_controller_id\x18\x03 \x01(\t\"y\n!DeleteNvmeRemoteControllerRequest\x12=\n\x04name\x18\x01 \x01(\tB/\xe0\x41\x02\xfa\x41)\n\'opi_api.storage.v1/NvmeRemoteController\x12\x15\n\rallow_missing\x18\x02 \x01(\x08\"\xb5\x01\n!UpdateNvmeRemoteControllerRequest\x12H\n\x16nvme_remote_controller\x18\x01 \x01(\x0b\x32(.opi_api.storage.v1.NvmeRemoteController\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12\x15\n\rallow_missing\x18\x03 \x01(\x08\"\x8a\x01\n ListNvmeRemoteControllersRequest\x12?\n\x06parent\x18\x01 \x01(\tB/\xe0\x41\x02\xfa\x41)\n\'opi_api.storage.v1/NvmeRemoteController\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"\x87\x01\n!ListNvmeRemoteControllersResponse\x12I\n\x17nvme_remote_controllers\x18\x01 \x03(\x0b\x32(.opi_api.storage.v1.NvmeRemoteController\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"_\n\x1eGetNvmeRemoteControllerRequest\x12=\n\x04name\x18\x01 \x01(\tB/\xe0\x41\x02\xfa\x41)\n\'opi_api.storage.v1/NvmeRemoteController\"L\n NvmeRemoteControllerResetRequest\x12(\n\x02id\x18\x01 \x01(\x0b\x32\x1c.opi_api.common.v1.ObjectKey\"L\n NvmeRemoteControllerStatsRequest\x12(\n\x02id\x18\x01 \x01(\x0b\x32\x1c.opi_api.common.v1.ObjectKey\"S\n!NvmeRemoteControllerStatsResponse\x12.\n\x05stats\x18\x01 \x01(\x0b\x32\x1f.opi_api.storage.v1.VolumeStats\"\x88\x01\n\x1fListNvmeRemoteNamespacesRequest\x12>\n\x06parent\x18\x01 \x01(\tB.\xe0\x41\x02\xfa\x41(\n&opi_api.storage.v1/NvmeRemoteNamespace\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"\x84\x01\n ListNvmeRemoteNamespacesResponse\x12G\n\x16nvme_remote_namespaces\x18\x01 \x03(\x0b\x32\'.opi_api.storage.v1.NvmeRemoteNamespace\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"c\n\x15\x43reateNvmePathRequest\x12\x34\n\tnvme_path\x18\x01 \x01(\x0b\x32\x1c.opi_api.storage.v1.NvmePathB\x03\xe0\x41\x02\x12\x14\n\x0cnvme_path_id\x18\x02 \x01(\t\"a\n\x15\x44\x65leteNvmePathRequest\x12\x31\n\x04name\x18\x01 \x01(\tB#\xe0\x41\x02\xfa\x41\x1d\n\x1bopi_api.storage.v1/NvmePath\x12\x15\n\rallow_missing\x18\x02 \x01(\x08\"\x90\x01\n\x15UpdateNvmePathRequest\x12/\n\tnvme_path\x18\x01 \x01(\x0b\x32\x1c.opi_api.storage.v1.NvmePath\x12/\n\x0bupdate_mask\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.FieldMask\x12\x15\n\rallow_missing\x18\x03 \x01(\x08\"r\n\x14ListNvmePathsRequest\x12\x33\n\x06parent\x18\x01 \x01(\tB#\xe0\x41\x02\xfa\x41\x1d\n\x1bopi_api.storage.v1/NvmePath\x12\x11\n\tpage_size\x18\x02 \x01(\x05\x12\x12\n\npage_token\x18\x03 \x01(\t\"b\n\x15ListNvmePathsResponse\x12\x30\n\nnvme_paths\x18\x01 \x03(\x0b\x32\x1c.opi_api.storage.v1.NvmePath\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\"G\n\x12GetNvmePathRequest\x12\x31\n\x04name\x18\x01 \x01(\tB#\xe0\x41\x02\xfa\x41\x1d\n\x1bopi_api.storage.v1/NvmePath\"@\n\x14NvmePathStatsRequest\x12(\n\x02id\x18\x01 \x01(\x0b\x32\x1c.opi_api.common.v1.ObjectKey\"G\n\x15NvmePathStatsResponse\x12.\n\x05stats\x18\x01 \x01(\x0b\x32\x1f.opi_api.storage.v1.VolumeStats*\xb4\x01\n\x11NvmeTransportType\x12#\n\x1fNVME_TRANSPORT_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11NVME_TRANSPORT_FC\x10\x01\x12\x17\n\x13NVME_TRANSPORT_PCIE\x10\x02\x12\x17\n\x13NVME_TRANSPORT_RDMA\x10\x03\x12\x16\n\x12NVME_TRANSPORT_TCP\x10\x04\x12\x19\n\x15NVME_TRANSPORT_CUSTOM\x10\x05*\xa8\x01\n\x11NvmeAddressFamily\x12#\n\x1fNVME_ADDRESS_FAMILY_UNSPECIFIED\x10\x00\x12\x14\n\x10NVME_ADRFAM_IPV4\x10\x01\x12\x14\n\x10NVME_ADRFAM_IPV6\x10\x02\x12\x12\n\x0eNVME_ADRFAM_IB\x10\x03\x12\x12\n\x0eNVME_ADRFAM_FC\x10\x04\x12\x1a\n\x16NVME_ADRFAM_INTRA_HOST\x10\x05*\x86\x01\n\rNvmeMultipath\x12\x1e\n\x1aNVME_MULTIPATH_UNSPECIFIED\x10\x00\x12\x1a\n\x16NVME_MULTIPATH_DISABLE\x10\x01\x12\x1b\n\x17NVME_MULTIPATH_FAILOVER\x10\x02\x12\x1c\n\x18NVME_MULTIPATH_MULTIPATH\x10\x03\x32\xe3\x11\n\x1bNvmeRemoteControllerService\x12\xdd\x01\n\x1a\x43reateNvmeRemoteController\x12\x35.opi_api.storage.v1.CreateNvmeRemoteControllerRequest\x1a(.opi_api.storage.v1.NvmeRemoteController\"^\x82\xd3\xe4\x93\x02%\"\x0b/v1/volumes:\x16nvme_remote_controller\xda\x41\x30nvme_remote_controller,nvme_remote_controller_id\x12\x9d\x01\n\x1a\x44\x65leteNvmeRemoteController\x12\x35.opi_api.storage.v1.DeleteNvmeRemoteControllerRequest\x1a\x16.google.protobuf.Empty\"0\x82\xd3\xe4\x93\x02#*!/v1/{name=subsystems}/{subsystem}\xda\x41\x04name\x12\xf0\x01\n\x1aUpdateNvmeRemoteController\x12\x35.opi_api.storage.v1.UpdateNvmeRemoteControllerRequest\x1a(.opi_api.storage.v1.NvmeRemoteController\"q\x82\xd3\xe4\x93\x02\x46\x32,/v1/{nvme_remote_controller.name=subsystems}:\x16nvme_remote_controller\xda\x41\"nvme_remote_controller,update_mask\x12\xb2\x01\n\x19ListNvmeRemoteControllers\x12\x34.opi_api.storage.v1.ListNvmeRemoteControllersRequest\x1a\x35.opi_api.storage.v1.ListNvmeRemoteControllersResponse\"(\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/{parent=subsystems}\xda\x41\x06parent\x12\xa9\x01\n\x17GetNvmeRemoteController\x12\x32.opi_api.storage.v1.GetNvmeRemoteControllerRequest\x1a(.opi_api.storage.v1.NvmeRemoteController\"0\x82\xd3\xe4\x93\x02#\x12!/v1/{name=subsystems}/{subsystem}\xda\x41\x04name\x12k\n\x19NvmeRemoteControllerReset\x12\x34.opi_api.storage.v1.NvmeRemoteControllerResetRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\x8a\x01\n\x19NvmeRemoteControllerStats\x12\x34.opi_api.storage.v1.NvmeRemoteControllerStatsRequest\x1a\x35.opi_api.storage.v1.NvmeRemoteControllerStatsResponse\"\x00\x12\xaf\x01\n\x18ListNvmeRemoteNamespaces\x12\x33.opi_api.storage.v1.ListNvmeRemoteNamespacesRequest\x1a\x34.opi_api.storage.v1.ListNvmeRemoteNamespacesResponse\"(\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/{parent=subsystems}\xda\x41\x06parent\x12\x92\x01\n\x0e\x43reateNvmePath\x12).opi_api.storage.v1.CreateNvmePathRequest\x1a\x1c.opi_api.storage.v1.NvmePath\"7\x82\xd3\xe4\x93\x02\x18\"\x0b/v1/volumes:\tnvme_path\xda\x41\x16nvme_path,nvme_path_id\x12\x85\x01\n\x0e\x44\x65leteNvmePath\x12).opi_api.storage.v1.DeleteNvmePathRequest\x1a\x16.google.protobuf.Empty\"0\x82\xd3\xe4\x93\x02#*!/v1/{name=subsystems}/{subsystem}\xda\x41\x04name\x12\xa5\x01\n\x0eUpdateNvmePath\x12).opi_api.storage.v1.UpdateNvmePathRequest\x1a\x1c.opi_api.storage.v1.NvmePath\"J\x82\xd3\xe4\x93\x02,2\x1f/v1/{nvme_path.name=subsystems}:\tnvme_path\xda\x41\x15nvme_path,update_mask\x12\x8e\x01\n\rListNvmePaths\x12(.opi_api.storage.v1.ListNvmePathsRequest\x1a).opi_api.storage.v1.ListNvmePathsResponse\"(\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/{parent=subsystems}\xda\x41\x06parent\x12\x85\x01\n\x0bGetNvmePath\x12&.opi_api.storage.v1.GetNvmePathRequest\x1a\x1c.opi_api.storage.v1.NvmePath\"0\x82\xd3\xe4\x93\x02#\x12!/v1/{name=subsystems}/{subsystem}\xda\x41\x04name\x12\x66\n\rNvmePathStats\x12(.opi_api.storage.v1.NvmePathStatsRequest\x1a).opi_api.storage.v1.NvmePathStatsResponse\"\x00\x42\x62\n\x12opi_api.storage.v1B\x13\x42\x61\x63kendNvmeTcpProtoP\x01Z5github.com/opiproject/opi-api/storage/v1alpha1/gen/gob\x06proto3')
 
 _NVMETRANSPORTTYPE = DESCRIPTOR.enum_types_by_name['NvmeTransportType']
 NvmeTransportType = enum_type_wrapper.EnumTypeWrapper(_NVMETRANSPORTTYPE)
@@ -38,148 +39,294 @@ NVME_TRANSPORT_RDMA = 3
 NVME_TRANSPORT_TCP = 4
 NVME_TRANSPORT_CUSTOM = 5
 NVME_ADDRESS_FAMILY_UNSPECIFIED = 0
-NVMF_ADRFAM_IPV4 = 1
-NVMF_ADRFAM_IPV6 = 2
-NVMF_ADRFAM_IB = 3
-NVMF_ADRFAM_FC = 4
-NVMF_ADRFAM_INTRA_HOST = 5
+NVME_ADRFAM_IPV4 = 1
+NVME_ADRFAM_IPV6 = 2
+NVME_ADRFAM_IB = 3
+NVME_ADRFAM_FC = 4
+NVME_ADRFAM_INTRA_HOST = 5
 NVME_MULTIPATH_UNSPECIFIED = 0
 NVME_MULTIPATH_DISABLE = 1
 NVME_MULTIPATH_FAILOVER = 2
 NVME_MULTIPATH_MULTIPATH = 3
 
 
-_NVMFREMOTECONTROLLER = DESCRIPTOR.message_types_by_name['NVMfRemoteController']
-_CREATENVMFREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['CreateNVMfRemoteControllerRequest']
-_DELETENVMFREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['DeleteNVMfRemoteControllerRequest']
-_UPDATENVMFREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['UpdateNVMfRemoteControllerRequest']
-_LISTNVMFREMOTECONTROLLERSREQUEST = DESCRIPTOR.message_types_by_name['ListNVMfRemoteControllersRequest']
-_LISTNVMFREMOTECONTROLLERSRESPONSE = DESCRIPTOR.message_types_by_name['ListNVMfRemoteControllersResponse']
-_GETNVMFREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['GetNVMfRemoteControllerRequest']
-_NVMFREMOTECONTROLLERRESETREQUEST = DESCRIPTOR.message_types_by_name['NVMfRemoteControllerResetRequest']
-_NVMFREMOTECONTROLLERSTATSREQUEST = DESCRIPTOR.message_types_by_name['NVMfRemoteControllerStatsRequest']
-_NVMFREMOTECONTROLLERSTATSRESPONSE = DESCRIPTOR.message_types_by_name['NVMfRemoteControllerStatsResponse']
-NVMfRemoteController = _reflection.GeneratedProtocolMessageType('NVMfRemoteController', (_message.Message,), {
-  'DESCRIPTOR' : _NVMFREMOTECONTROLLER,
+_NVMEREMOTECONTROLLER = DESCRIPTOR.message_types_by_name['NvmeRemoteController']
+_NVMEPATH = DESCRIPTOR.message_types_by_name['NvmePath']
+_NVMEREMOTENAMESPACE = DESCRIPTOR.message_types_by_name['NvmeRemoteNamespace']
+_CREATENVMEREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['CreateNvmeRemoteControllerRequest']
+_DELETENVMEREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['DeleteNvmeRemoteControllerRequest']
+_UPDATENVMEREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['UpdateNvmeRemoteControllerRequest']
+_LISTNVMEREMOTECONTROLLERSREQUEST = DESCRIPTOR.message_types_by_name['ListNvmeRemoteControllersRequest']
+_LISTNVMEREMOTECONTROLLERSRESPONSE = DESCRIPTOR.message_types_by_name['ListNvmeRemoteControllersResponse']
+_GETNVMEREMOTECONTROLLERREQUEST = DESCRIPTOR.message_types_by_name['GetNvmeRemoteControllerRequest']
+_NVMEREMOTECONTROLLERRESETREQUEST = DESCRIPTOR.message_types_by_name['NvmeRemoteControllerResetRequest']
+_NVMEREMOTECONTROLLERSTATSREQUEST = DESCRIPTOR.message_types_by_name['NvmeRemoteControllerStatsRequest']
+_NVMEREMOTECONTROLLERSTATSRESPONSE = DESCRIPTOR.message_types_by_name['NvmeRemoteControllerStatsResponse']
+_LISTNVMEREMOTENAMESPACESREQUEST = DESCRIPTOR.message_types_by_name['ListNvmeRemoteNamespacesRequest']
+_LISTNVMEREMOTENAMESPACESRESPONSE = DESCRIPTOR.message_types_by_name['ListNvmeRemoteNamespacesResponse']
+_CREATENVMEPATHREQUEST = DESCRIPTOR.message_types_by_name['CreateNvmePathRequest']
+_DELETENVMEPATHREQUEST = DESCRIPTOR.message_types_by_name['DeleteNvmePathRequest']
+_UPDATENVMEPATHREQUEST = DESCRIPTOR.message_types_by_name['UpdateNvmePathRequest']
+_LISTNVMEPATHSREQUEST = DESCRIPTOR.message_types_by_name['ListNvmePathsRequest']
+_LISTNVMEPATHSRESPONSE = DESCRIPTOR.message_types_by_name['ListNvmePathsResponse']
+_GETNVMEPATHREQUEST = DESCRIPTOR.message_types_by_name['GetNvmePathRequest']
+_NVMEPATHSTATSREQUEST = DESCRIPTOR.message_types_by_name['NvmePathStatsRequest']
+_NVMEPATHSTATSRESPONSE = DESCRIPTOR.message_types_by_name['NvmePathStatsResponse']
+NvmeRemoteController = _reflection.GeneratedProtocolMessageType('NvmeRemoteController', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEREMOTECONTROLLER,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NVMfRemoteController)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmeRemoteController)
   })
-_sym_db.RegisterMessage(NVMfRemoteController)
+_sym_db.RegisterMessage(NvmeRemoteController)
 
-CreateNVMfRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('CreateNVMfRemoteControllerRequest', (_message.Message,), {
-  'DESCRIPTOR' : _CREATENVMFREMOTECONTROLLERREQUEST,
+NvmePath = _reflection.GeneratedProtocolMessageType('NvmePath', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEPATH,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.CreateNVMfRemoteControllerRequest)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmePath)
   })
-_sym_db.RegisterMessage(CreateNVMfRemoteControllerRequest)
+_sym_db.RegisterMessage(NvmePath)
 
-DeleteNVMfRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('DeleteNVMfRemoteControllerRequest', (_message.Message,), {
-  'DESCRIPTOR' : _DELETENVMFREMOTECONTROLLERREQUEST,
+NvmeRemoteNamespace = _reflection.GeneratedProtocolMessageType('NvmeRemoteNamespace', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEREMOTENAMESPACE,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.DeleteNVMfRemoteControllerRequest)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmeRemoteNamespace)
   })
-_sym_db.RegisterMessage(DeleteNVMfRemoteControllerRequest)
+_sym_db.RegisterMessage(NvmeRemoteNamespace)
 
-UpdateNVMfRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('UpdateNVMfRemoteControllerRequest', (_message.Message,), {
-  'DESCRIPTOR' : _UPDATENVMFREMOTECONTROLLERREQUEST,
+CreateNvmeRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('CreateNvmeRemoteControllerRequest', (_message.Message,), {
+  'DESCRIPTOR' : _CREATENVMEREMOTECONTROLLERREQUEST,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.UpdateNVMfRemoteControllerRequest)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.CreateNvmeRemoteControllerRequest)
   })
-_sym_db.RegisterMessage(UpdateNVMfRemoteControllerRequest)
+_sym_db.RegisterMessage(CreateNvmeRemoteControllerRequest)
 
-ListNVMfRemoteControllersRequest = _reflection.GeneratedProtocolMessageType('ListNVMfRemoteControllersRequest', (_message.Message,), {
-  'DESCRIPTOR' : _LISTNVMFREMOTECONTROLLERSREQUEST,
+DeleteNvmeRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('DeleteNvmeRemoteControllerRequest', (_message.Message,), {
+  'DESCRIPTOR' : _DELETENVMEREMOTECONTROLLERREQUEST,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNVMfRemoteControllersRequest)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.DeleteNvmeRemoteControllerRequest)
   })
-_sym_db.RegisterMessage(ListNVMfRemoteControllersRequest)
+_sym_db.RegisterMessage(DeleteNvmeRemoteControllerRequest)
 
-ListNVMfRemoteControllersResponse = _reflection.GeneratedProtocolMessageType('ListNVMfRemoteControllersResponse', (_message.Message,), {
-  'DESCRIPTOR' : _LISTNVMFREMOTECONTROLLERSRESPONSE,
+UpdateNvmeRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('UpdateNvmeRemoteControllerRequest', (_message.Message,), {
+  'DESCRIPTOR' : _UPDATENVMEREMOTECONTROLLERREQUEST,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNVMfRemoteControllersResponse)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.UpdateNvmeRemoteControllerRequest)
   })
-_sym_db.RegisterMessage(ListNVMfRemoteControllersResponse)
+_sym_db.RegisterMessage(UpdateNvmeRemoteControllerRequest)
 
-GetNVMfRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('GetNVMfRemoteControllerRequest', (_message.Message,), {
-  'DESCRIPTOR' : _GETNVMFREMOTECONTROLLERREQUEST,
+ListNvmeRemoteControllersRequest = _reflection.GeneratedProtocolMessageType('ListNvmeRemoteControllersRequest', (_message.Message,), {
+  'DESCRIPTOR' : _LISTNVMEREMOTECONTROLLERSREQUEST,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.GetNVMfRemoteControllerRequest)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNvmeRemoteControllersRequest)
   })
-_sym_db.RegisterMessage(GetNVMfRemoteControllerRequest)
+_sym_db.RegisterMessage(ListNvmeRemoteControllersRequest)
 
-NVMfRemoteControllerResetRequest = _reflection.GeneratedProtocolMessageType('NVMfRemoteControllerResetRequest', (_message.Message,), {
-  'DESCRIPTOR' : _NVMFREMOTECONTROLLERRESETREQUEST,
+ListNvmeRemoteControllersResponse = _reflection.GeneratedProtocolMessageType('ListNvmeRemoteControllersResponse', (_message.Message,), {
+  'DESCRIPTOR' : _LISTNVMEREMOTECONTROLLERSRESPONSE,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NVMfRemoteControllerResetRequest)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNvmeRemoteControllersResponse)
   })
-_sym_db.RegisterMessage(NVMfRemoteControllerResetRequest)
+_sym_db.RegisterMessage(ListNvmeRemoteControllersResponse)
 
-NVMfRemoteControllerStatsRequest = _reflection.GeneratedProtocolMessageType('NVMfRemoteControllerStatsRequest', (_message.Message,), {
-  'DESCRIPTOR' : _NVMFREMOTECONTROLLERSTATSREQUEST,
+GetNvmeRemoteControllerRequest = _reflection.GeneratedProtocolMessageType('GetNvmeRemoteControllerRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETNVMEREMOTECONTROLLERREQUEST,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NVMfRemoteControllerStatsRequest)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.GetNvmeRemoteControllerRequest)
   })
-_sym_db.RegisterMessage(NVMfRemoteControllerStatsRequest)
+_sym_db.RegisterMessage(GetNvmeRemoteControllerRequest)
 
-NVMfRemoteControllerStatsResponse = _reflection.GeneratedProtocolMessageType('NVMfRemoteControllerStatsResponse', (_message.Message,), {
-  'DESCRIPTOR' : _NVMFREMOTECONTROLLERSTATSRESPONSE,
+NvmeRemoteControllerResetRequest = _reflection.GeneratedProtocolMessageType('NvmeRemoteControllerResetRequest', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEREMOTECONTROLLERRESETREQUEST,
   '__module__' : 'backend_nvme_tcp_pb2'
-  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NVMfRemoteControllerStatsResponse)
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmeRemoteControllerResetRequest)
   })
-_sym_db.RegisterMessage(NVMfRemoteControllerStatsResponse)
+_sym_db.RegisterMessage(NvmeRemoteControllerResetRequest)
 
-_NVMFREMOTECONTROLLERSERVICE = DESCRIPTOR.services_by_name['NVMfRemoteControllerService']
+NvmeRemoteControllerStatsRequest = _reflection.GeneratedProtocolMessageType('NvmeRemoteControllerStatsRequest', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEREMOTECONTROLLERSTATSREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmeRemoteControllerStatsRequest)
+  })
+_sym_db.RegisterMessage(NvmeRemoteControllerStatsRequest)
+
+NvmeRemoteControllerStatsResponse = _reflection.GeneratedProtocolMessageType('NvmeRemoteControllerStatsResponse', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEREMOTECONTROLLERSTATSRESPONSE,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmeRemoteControllerStatsResponse)
+  })
+_sym_db.RegisterMessage(NvmeRemoteControllerStatsResponse)
+
+ListNvmeRemoteNamespacesRequest = _reflection.GeneratedProtocolMessageType('ListNvmeRemoteNamespacesRequest', (_message.Message,), {
+  'DESCRIPTOR' : _LISTNVMEREMOTENAMESPACESREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNvmeRemoteNamespacesRequest)
+  })
+_sym_db.RegisterMessage(ListNvmeRemoteNamespacesRequest)
+
+ListNvmeRemoteNamespacesResponse = _reflection.GeneratedProtocolMessageType('ListNvmeRemoteNamespacesResponse', (_message.Message,), {
+  'DESCRIPTOR' : _LISTNVMEREMOTENAMESPACESRESPONSE,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNvmeRemoteNamespacesResponse)
+  })
+_sym_db.RegisterMessage(ListNvmeRemoteNamespacesResponse)
+
+CreateNvmePathRequest = _reflection.GeneratedProtocolMessageType('CreateNvmePathRequest', (_message.Message,), {
+  'DESCRIPTOR' : _CREATENVMEPATHREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.CreateNvmePathRequest)
+  })
+_sym_db.RegisterMessage(CreateNvmePathRequest)
+
+DeleteNvmePathRequest = _reflection.GeneratedProtocolMessageType('DeleteNvmePathRequest', (_message.Message,), {
+  'DESCRIPTOR' : _DELETENVMEPATHREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.DeleteNvmePathRequest)
+  })
+_sym_db.RegisterMessage(DeleteNvmePathRequest)
+
+UpdateNvmePathRequest = _reflection.GeneratedProtocolMessageType('UpdateNvmePathRequest', (_message.Message,), {
+  'DESCRIPTOR' : _UPDATENVMEPATHREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.UpdateNvmePathRequest)
+  })
+_sym_db.RegisterMessage(UpdateNvmePathRequest)
+
+ListNvmePathsRequest = _reflection.GeneratedProtocolMessageType('ListNvmePathsRequest', (_message.Message,), {
+  'DESCRIPTOR' : _LISTNVMEPATHSREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNvmePathsRequest)
+  })
+_sym_db.RegisterMessage(ListNvmePathsRequest)
+
+ListNvmePathsResponse = _reflection.GeneratedProtocolMessageType('ListNvmePathsResponse', (_message.Message,), {
+  'DESCRIPTOR' : _LISTNVMEPATHSRESPONSE,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.ListNvmePathsResponse)
+  })
+_sym_db.RegisterMessage(ListNvmePathsResponse)
+
+GetNvmePathRequest = _reflection.GeneratedProtocolMessageType('GetNvmePathRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETNVMEPATHREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.GetNvmePathRequest)
+  })
+_sym_db.RegisterMessage(GetNvmePathRequest)
+
+NvmePathStatsRequest = _reflection.GeneratedProtocolMessageType('NvmePathStatsRequest', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEPATHSTATSREQUEST,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmePathStatsRequest)
+  })
+_sym_db.RegisterMessage(NvmePathStatsRequest)
+
+NvmePathStatsResponse = _reflection.GeneratedProtocolMessageType('NvmePathStatsResponse', (_message.Message,), {
+  'DESCRIPTOR' : _NVMEPATHSTATSRESPONSE,
+  '__module__' : 'backend_nvme_tcp_pb2'
+  # @@protoc_insertion_point(class_scope:opi_api.storage.v1.NvmePathStatsResponse)
+  })
+_sym_db.RegisterMessage(NvmePathStatsResponse)
+
+_NVMEREMOTECONTROLLERSERVICE = DESCRIPTOR.services_by_name['NvmeRemoteControllerService']
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n\022opi_api.storage.v1B\023BackendNvmeTcpProtoP\001Z5github.com/opiproject/opi-api/storage/v1alpha1/gen/go'
-  _NVMFREMOTECONTROLLER._options = None
-  _NVMFREMOTECONTROLLER._serialized_options = b'\352A?\n+storage.opiproject.org/NVMfRemoteController\022\020volumes/{volume}'
-  _CREATENVMFREMOTECONTROLLERREQUEST.fields_by_name['nv_mf_remote_controller']._options = None
-  _CREATENVMFREMOTECONTROLLERREQUEST.fields_by_name['nv_mf_remote_controller']._serialized_options = b'\340A\002'
-  _DELETENVMFREMOTECONTROLLERREQUEST.fields_by_name['name']._options = None
-  _DELETENVMFREMOTECONTROLLERREQUEST.fields_by_name['name']._serialized_options = b'\340A\002\372A)\n\'opi_api.storage.v1/NVMfRemoteController'
-  _LISTNVMFREMOTECONTROLLERSREQUEST.fields_by_name['parent']._options = None
-  _LISTNVMFREMOTECONTROLLERSREQUEST.fields_by_name['parent']._serialized_options = b'\340A\002\372A)\n\'opi_api.storage.v1/NVMfRemoteController'
-  _GETNVMFREMOTECONTROLLERREQUEST.fields_by_name['name']._options = None
-  _GETNVMFREMOTECONTROLLERREQUEST.fields_by_name['name']._serialized_options = b'\340A\002\372A)\n\'opi_api.storage.v1/NVMfRemoteController'
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['CreateNVMfRemoteController']._options = None
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['CreateNVMfRemoteController']._serialized_options = b'\202\323\344\223\002&\"\013/v1/volumes:\027nv_mf_remote_controller\332A2nv_mf_remote_controller,nv_mf_remote_controller_id'
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['DeleteNVMfRemoteController']._options = None
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['DeleteNVMfRemoteController']._serialized_options = b'\202\323\344\223\002#*!/v1/{name=subsystems}/{subsystem}\332A\004name'
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['UpdateNVMfRemoteController']._options = None
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['UpdateNVMfRemoteController']._serialized_options = b'\202\323\344\223\002H2-/v1/{nv_mf_remote_controller.name=subsystems}:\027nv_mf_remote_controller\332A#nv_mf_remote_controller,update_mask'
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['ListNVMfRemoteControllers']._options = None
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['ListNVMfRemoteControllers']._serialized_options = b'\202\323\344\223\002\031\022\027/v1/{parent=subsystems}\332A\006parent'
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['GetNVMfRemoteController']._options = None
-  _NVMFREMOTECONTROLLERSERVICE.methods_by_name['GetNVMfRemoteController']._serialized_options = b'\202\323\344\223\002#\022!/v1/{name=subsystems}/{subsystem}\332A\004name'
-  _NVMETRANSPORTTYPE._serialized_start=1752
-  _NVMETRANSPORTTYPE._serialized_end=1932
-  _NVMEADDRESSFAMILY._serialized_start=1935
-  _NVMEADDRESSFAMILY._serialized_end=2103
-  _NVMEMULTIPATH._serialized_start=2106
-  _NVMEMULTIPATH._serialized_end=2240
-  _NVMFREMOTECONTROLLER._serialized_start=260
-  _NVMFREMOTECONTROLLER._serialized_end=669
-  _CREATENVMFREMOTECONTROLLERREQUEST._serialized_start=672
-  _CREATENVMFREMOTECONTROLLERREQUEST._serialized_end=823
-  _DELETENVMFREMOTECONTROLLERREQUEST._serialized_start=825
-  _DELETENVMFREMOTECONTROLLERREQUEST._serialized_end=946
-  _UPDATENVMFREMOTECONTROLLERREQUEST._serialized_start=949
-  _UPDATENVMFREMOTECONTROLLERREQUEST._serialized_end=1131
-  _LISTNVMFREMOTECONTROLLERSREQUEST._serialized_start=1134
-  _LISTNVMFREMOTECONTROLLERSREQUEST._serialized_end=1272
-  _LISTNVMFREMOTECONTROLLERSRESPONSE._serialized_start=1275
-  _LISTNVMFREMOTECONTROLLERSRESPONSE._serialized_end=1411
-  _GETNVMFREMOTECONTROLLERREQUEST._serialized_start=1413
-  _GETNVMFREMOTECONTROLLERREQUEST._serialized_end=1508
-  _NVMFREMOTECONTROLLERRESETREQUEST._serialized_start=1510
-  _NVMFREMOTECONTROLLERRESETREQUEST._serialized_end=1586
-  _NVMFREMOTECONTROLLERSTATSREQUEST._serialized_start=1588
-  _NVMFREMOTECONTROLLERSTATSREQUEST._serialized_end=1664
-  _NVMFREMOTECONTROLLERSTATSRESPONSE._serialized_start=1666
-  _NVMFREMOTECONTROLLERSTATSRESPONSE._serialized_end=1749
-  _NVMFREMOTECONTROLLERSERVICE._serialized_start=2243
-  _NVMFREMOTECONTROLLERSERVICE._serialized_end=3508
+  _NVMEREMOTECONTROLLER._options = None
+  _NVMEREMOTECONTROLLER._serialized_options = b'\352A?\n+storage.opiproject.org/NvmeRemoteController\022\020volumes/{volume}'
+  _NVMEPATH._options = None
+  _NVMEPATH._serialized_options = b'\352A3\n\037storage.opiproject.org/NvmePath\022\020volumes/{volume}'
+  _NVMEREMOTENAMESPACE._options = None
+  _NVMEREMOTENAMESPACE._serialized_options = b'\352A>\n*storage.opiproject.org/NvmeRemoteNamespace\022\020volumes/{volume}'
+  _CREATENVMEREMOTECONTROLLERREQUEST.fields_by_name['nvme_remote_controller']._options = None
+  _CREATENVMEREMOTECONTROLLERREQUEST.fields_by_name['nvme_remote_controller']._serialized_options = b'\340A\002'
+  _DELETENVMEREMOTECONTROLLERREQUEST.fields_by_name['name']._options = None
+  _DELETENVMEREMOTECONTROLLERREQUEST.fields_by_name['name']._serialized_options = b'\340A\002\372A)\n\'opi_api.storage.v1/NvmeRemoteController'
+  _LISTNVMEREMOTECONTROLLERSREQUEST.fields_by_name['parent']._options = None
+  _LISTNVMEREMOTECONTROLLERSREQUEST.fields_by_name['parent']._serialized_options = b'\340A\002\372A)\n\'opi_api.storage.v1/NvmeRemoteController'
+  _GETNVMEREMOTECONTROLLERREQUEST.fields_by_name['name']._options = None
+  _GETNVMEREMOTECONTROLLERREQUEST.fields_by_name['name']._serialized_options = b'\340A\002\372A)\n\'opi_api.storage.v1/NvmeRemoteController'
+  _LISTNVMEREMOTENAMESPACESREQUEST.fields_by_name['parent']._options = None
+  _LISTNVMEREMOTENAMESPACESREQUEST.fields_by_name['parent']._serialized_options = b'\340A\002\372A(\n&opi_api.storage.v1/NvmeRemoteNamespace'
+  _CREATENVMEPATHREQUEST.fields_by_name['nvme_path']._options = None
+  _CREATENVMEPATHREQUEST.fields_by_name['nvme_path']._serialized_options = b'\340A\002'
+  _DELETENVMEPATHREQUEST.fields_by_name['name']._options = None
+  _DELETENVMEPATHREQUEST.fields_by_name['name']._serialized_options = b'\340A\002\372A\035\n\033opi_api.storage.v1/NvmePath'
+  _LISTNVMEPATHSREQUEST.fields_by_name['parent']._options = None
+  _LISTNVMEPATHSREQUEST.fields_by_name['parent']._serialized_options = b'\340A\002\372A\035\n\033opi_api.storage.v1/NvmePath'
+  _GETNVMEPATHREQUEST.fields_by_name['name']._options = None
+  _GETNVMEPATHREQUEST.fields_by_name['name']._serialized_options = b'\340A\002\372A\035\n\033opi_api.storage.v1/NvmePath'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['CreateNvmeRemoteController']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['CreateNvmeRemoteController']._serialized_options = b'\202\323\344\223\002%\"\013/v1/volumes:\026nvme_remote_controller\332A0nvme_remote_controller,nvme_remote_controller_id'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['DeleteNvmeRemoteController']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['DeleteNvmeRemoteController']._serialized_options = b'\202\323\344\223\002#*!/v1/{name=subsystems}/{subsystem}\332A\004name'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['UpdateNvmeRemoteController']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['UpdateNvmeRemoteController']._serialized_options = b'\202\323\344\223\002F2,/v1/{nvme_remote_controller.name=subsystems}:\026nvme_remote_controller\332A\"nvme_remote_controller,update_mask'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['ListNvmeRemoteControllers']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['ListNvmeRemoteControllers']._serialized_options = b'\202\323\344\223\002\031\022\027/v1/{parent=subsystems}\332A\006parent'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['GetNvmeRemoteController']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['GetNvmeRemoteController']._serialized_options = b'\202\323\344\223\002#\022!/v1/{name=subsystems}/{subsystem}\332A\004name'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['ListNvmeRemoteNamespaces']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['ListNvmeRemoteNamespaces']._serialized_options = b'\202\323\344\223\002\031\022\027/v1/{parent=subsystems}\332A\006parent'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['CreateNvmePath']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['CreateNvmePath']._serialized_options = b'\202\323\344\223\002\030\"\013/v1/volumes:\tnvme_path\332A\026nvme_path,nvme_path_id'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['DeleteNvmePath']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['DeleteNvmePath']._serialized_options = b'\202\323\344\223\002#*!/v1/{name=subsystems}/{subsystem}\332A\004name'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['UpdateNvmePath']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['UpdateNvmePath']._serialized_options = b'\202\323\344\223\002,2\037/v1/{nvme_path.name=subsystems}:\tnvme_path\332A\025nvme_path,update_mask'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['ListNvmePaths']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['ListNvmePaths']._serialized_options = b'\202\323\344\223\002\031\022\027/v1/{parent=subsystems}\332A\006parent'
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['GetNvmePath']._options = None
+  _NVMEREMOTECONTROLLERSERVICE.methods_by_name['GetNvmePath']._serialized_options = b'\202\323\344\223\002#\022!/v1/{name=subsystems}/{subsystem}\332A\004name'
+  _NVMETRANSPORTTYPE._serialized_start=3233
+  _NVMETRANSPORTTYPE._serialized_end=3413
+  _NVMEADDRESSFAMILY._serialized_start=3416
+  _NVMEADDRESSFAMILY._serialized_end=3584
+  _NVMEMULTIPATH._serialized_start=3587
+  _NVMEMULTIPATH._serialized_end=3721
+  _NVMEREMOTECONTROLLER._serialized_start=272
+  _NVMEREMOTECONTROLLER._serialized_end=505
+  _NVMEPATH._serialized_start=508
+  _NVMEPATH._serialized_end=864
+  _NVMEREMOTENAMESPACE._serialized_start=867
+  _NVMEREMOTENAMESPACE._serialized_end=1105
+  _CREATENVMEREMOTECONTROLLERREQUEST._serialized_start=1108
+  _CREATENVMEREMOTECONTROLLERREQUEST._serialized_end=1257
+  _DELETENVMEREMOTECONTROLLERREQUEST._serialized_start=1259
+  _DELETENVMEREMOTECONTROLLERREQUEST._serialized_end=1380
+  _UPDATENVMEREMOTECONTROLLERREQUEST._serialized_start=1383
+  _UPDATENVMEREMOTECONTROLLERREQUEST._serialized_end=1564
+  _LISTNVMEREMOTECONTROLLERSREQUEST._serialized_start=1567
+  _LISTNVMEREMOTECONTROLLERSREQUEST._serialized_end=1705
+  _LISTNVMEREMOTECONTROLLERSRESPONSE._serialized_start=1708
+  _LISTNVMEREMOTECONTROLLERSRESPONSE._serialized_end=1843
+  _GETNVMEREMOTECONTROLLERREQUEST._serialized_start=1845
+  _GETNVMEREMOTECONTROLLERREQUEST._serialized_end=1940
+  _NVMEREMOTECONTROLLERRESETREQUEST._serialized_start=1942
+  _NVMEREMOTECONTROLLERRESETREQUEST._serialized_end=2018
+  _NVMEREMOTECONTROLLERSTATSREQUEST._serialized_start=2020
+  _NVMEREMOTECONTROLLERSTATSREQUEST._serialized_end=2096
+  _NVMEREMOTECONTROLLERSTATSRESPONSE._serialized_start=2098
+  _NVMEREMOTECONTROLLERSTATSRESPONSE._serialized_end=2181
+  _LISTNVMEREMOTENAMESPACESREQUEST._serialized_start=2184
+  _LISTNVMEREMOTENAMESPACESREQUEST._serialized_end=2320
+  _LISTNVMEREMOTENAMESPACESRESPONSE._serialized_start=2323
+  _LISTNVMEREMOTENAMESPACESRESPONSE._serialized_end=2455
+  _CREATENVMEPATHREQUEST._serialized_start=2457
+  _CREATENVMEPATHREQUEST._serialized_end=2556
+  _DELETENVMEPATHREQUEST._serialized_start=2558
+  _DELETENVMEPATHREQUEST._serialized_end=2655
+  _UPDATENVMEPATHREQUEST._serialized_start=2658
+  _UPDATENVMEPATHREQUEST._serialized_end=2802
+  _LISTNVMEPATHSREQUEST._serialized_start=2804
+  _LISTNVMEPATHSREQUEST._serialized_end=2918
+  _LISTNVMEPATHSRESPONSE._serialized_start=2920
+  _LISTNVMEPATHSRESPONSE._serialized_end=3018
+  _GETNVMEPATHREQUEST._serialized_start=3020
+  _GETNVMEPATHREQUEST._serialized_end=3091
+  _NVMEPATHSTATSREQUEST._serialized_start=3093
+  _NVMEPATHSTATSREQUEST._serialized_end=3157
+  _NVMEPATHSTATSRESPONSE._serialized_start=3159
+  _NVMEPATHSTATSRESPONSE._serialized_end=3230
+  _NVMEREMOTECONTROLLERSERVICE._serialized_start=3724
+  _NVMEREMOTECONTROLLERSERVICE._serialized_end=5999
 # @@protoc_insertion_point(module_scope)

--- a/pydpu/proto/v1/backend_nvme_tcp_pb2_grpc.py
+++ b/pydpu/proto/v1/backend_nvme_tcp_pb2_grpc.py
@@ -6,7 +6,7 @@ import backend_nvme_tcp_pb2 as backend__nvme__tcp__pb2
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
-class NVMfRemoteControllerServiceStub(object):
+class NvmeRemoteControllerServiceStub(object):
     """Back End (network-facing) APIs. NVMe/TCP and NVMe/RoCEv2 protocols are covered by this service.
     """
 
@@ -16,140 +16,252 @@ class NVMfRemoteControllerServiceStub(object):
         Args:
             channel: A grpc.Channel.
         """
-        self.CreateNVMfRemoteController = channel.unary_unary(
-                '/opi_api.storage.v1.NVMfRemoteControllerService/CreateNVMfRemoteController',
-                request_serializer=backend__nvme__tcp__pb2.CreateNVMfRemoteControllerRequest.SerializeToString,
-                response_deserializer=backend__nvme__tcp__pb2.NVMfRemoteController.FromString,
+        self.CreateNvmeRemoteController = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/CreateNvmeRemoteController',
+                request_serializer=backend__nvme__tcp__pb2.CreateNvmeRemoteControllerRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmeRemoteController.FromString,
                 )
-        self.DeleteNVMfRemoteController = channel.unary_unary(
-                '/opi_api.storage.v1.NVMfRemoteControllerService/DeleteNVMfRemoteController',
-                request_serializer=backend__nvme__tcp__pb2.DeleteNVMfRemoteControllerRequest.SerializeToString,
+        self.DeleteNvmeRemoteController = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/DeleteNvmeRemoteController',
+                request_serializer=backend__nvme__tcp__pb2.DeleteNvmeRemoteControllerRequest.SerializeToString,
                 response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
                 )
-        self.UpdateNVMfRemoteController = channel.unary_unary(
-                '/opi_api.storage.v1.NVMfRemoteControllerService/UpdateNVMfRemoteController',
-                request_serializer=backend__nvme__tcp__pb2.UpdateNVMfRemoteControllerRequest.SerializeToString,
-                response_deserializer=backend__nvme__tcp__pb2.NVMfRemoteController.FromString,
+        self.UpdateNvmeRemoteController = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/UpdateNvmeRemoteController',
+                request_serializer=backend__nvme__tcp__pb2.UpdateNvmeRemoteControllerRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmeRemoteController.FromString,
                 )
-        self.ListNVMfRemoteControllers = channel.unary_unary(
-                '/opi_api.storage.v1.NVMfRemoteControllerService/ListNVMfRemoteControllers',
-                request_serializer=backend__nvme__tcp__pb2.ListNVMfRemoteControllersRequest.SerializeToString,
-                response_deserializer=backend__nvme__tcp__pb2.ListNVMfRemoteControllersResponse.FromString,
+        self.ListNvmeRemoteControllers = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/ListNvmeRemoteControllers',
+                request_serializer=backend__nvme__tcp__pb2.ListNvmeRemoteControllersRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.ListNvmeRemoteControllersResponse.FromString,
                 )
-        self.GetNVMfRemoteController = channel.unary_unary(
-                '/opi_api.storage.v1.NVMfRemoteControllerService/GetNVMfRemoteController',
-                request_serializer=backend__nvme__tcp__pb2.GetNVMfRemoteControllerRequest.SerializeToString,
-                response_deserializer=backend__nvme__tcp__pb2.NVMfRemoteController.FromString,
+        self.GetNvmeRemoteController = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/GetNvmeRemoteController',
+                request_serializer=backend__nvme__tcp__pb2.GetNvmeRemoteControllerRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmeRemoteController.FromString,
                 )
-        self.NVMfRemoteControllerReset = channel.unary_unary(
-                '/opi_api.storage.v1.NVMfRemoteControllerService/NVMfRemoteControllerReset',
-                request_serializer=backend__nvme__tcp__pb2.NVMfRemoteControllerResetRequest.SerializeToString,
+        self.NvmeRemoteControllerReset = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/NvmeRemoteControllerReset',
+                request_serializer=backend__nvme__tcp__pb2.NvmeRemoteControllerResetRequest.SerializeToString,
                 response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
                 )
-        self.NVMfRemoteControllerStats = channel.unary_unary(
-                '/opi_api.storage.v1.NVMfRemoteControllerService/NVMfRemoteControllerStats',
-                request_serializer=backend__nvme__tcp__pb2.NVMfRemoteControllerStatsRequest.SerializeToString,
-                response_deserializer=backend__nvme__tcp__pb2.NVMfRemoteControllerStatsResponse.FromString,
+        self.NvmeRemoteControllerStats = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/NvmeRemoteControllerStats',
+                request_serializer=backend__nvme__tcp__pb2.NvmeRemoteControllerStatsRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmeRemoteControllerStatsResponse.FromString,
+                )
+        self.ListNvmeRemoteNamespaces = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/ListNvmeRemoteNamespaces',
+                request_serializer=backend__nvme__tcp__pb2.ListNvmeRemoteNamespacesRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.ListNvmeRemoteNamespacesResponse.FromString,
+                )
+        self.CreateNvmePath = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/CreateNvmePath',
+                request_serializer=backend__nvme__tcp__pb2.CreateNvmePathRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmePath.FromString,
+                )
+        self.DeleteNvmePath = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/DeleteNvmePath',
+                request_serializer=backend__nvme__tcp__pb2.DeleteNvmePathRequest.SerializeToString,
+                response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+                )
+        self.UpdateNvmePath = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/UpdateNvmePath',
+                request_serializer=backend__nvme__tcp__pb2.UpdateNvmePathRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmePath.FromString,
+                )
+        self.ListNvmePaths = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/ListNvmePaths',
+                request_serializer=backend__nvme__tcp__pb2.ListNvmePathsRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.ListNvmePathsResponse.FromString,
+                )
+        self.GetNvmePath = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/GetNvmePath',
+                request_serializer=backend__nvme__tcp__pb2.GetNvmePathRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmePath.FromString,
+                )
+        self.NvmePathStats = channel.unary_unary(
+                '/opi_api.storage.v1.NvmeRemoteControllerService/NvmePathStats',
+                request_serializer=backend__nvme__tcp__pb2.NvmePathStatsRequest.SerializeToString,
+                response_deserializer=backend__nvme__tcp__pb2.NvmePathStatsResponse.FromString,
                 )
 
 
-class NVMfRemoteControllerServiceServicer(object):
+class NvmeRemoteControllerServiceServicer(object):
     """Back End (network-facing) APIs. NVMe/TCP and NVMe/RoCEv2 protocols are covered by this service.
     """
 
-    def CreateNVMfRemoteController(self, request, context):
+    def CreateNvmeRemoteController(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def DeleteNVMfRemoteController(self, request, context):
+    def DeleteNvmeRemoteController(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def UpdateNVMfRemoteController(self, request, context):
+    def UpdateNvmeRemoteController(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def ListNVMfRemoteControllers(self, request, context):
+    def ListNvmeRemoteControllers(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def GetNVMfRemoteController(self, request, context):
+    def GetNvmeRemoteController(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def NVMfRemoteControllerReset(self, request, context):
+    def NvmeRemoteControllerReset(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def NVMfRemoteControllerStats(self, request, context):
+    def NvmeRemoteControllerStats(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def ListNvmeRemoteNamespaces(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def CreateNvmePath(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def DeleteNvmePath(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def UpdateNvmePath(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def ListNvmePaths(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def GetNvmePath(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def NvmePathStats(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
 
-def add_NVMfRemoteControllerServiceServicer_to_server(servicer, server):
+def add_NvmeRemoteControllerServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
-            'CreateNVMfRemoteController': grpc.unary_unary_rpc_method_handler(
-                    servicer.CreateNVMfRemoteController,
-                    request_deserializer=backend__nvme__tcp__pb2.CreateNVMfRemoteControllerRequest.FromString,
-                    response_serializer=backend__nvme__tcp__pb2.NVMfRemoteController.SerializeToString,
+            'CreateNvmeRemoteController': grpc.unary_unary_rpc_method_handler(
+                    servicer.CreateNvmeRemoteController,
+                    request_deserializer=backend__nvme__tcp__pb2.CreateNvmeRemoteControllerRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmeRemoteController.SerializeToString,
             ),
-            'DeleteNVMfRemoteController': grpc.unary_unary_rpc_method_handler(
-                    servicer.DeleteNVMfRemoteController,
-                    request_deserializer=backend__nvme__tcp__pb2.DeleteNVMfRemoteControllerRequest.FromString,
+            'DeleteNvmeRemoteController': grpc.unary_unary_rpc_method_handler(
+                    servicer.DeleteNvmeRemoteController,
+                    request_deserializer=backend__nvme__tcp__pb2.DeleteNvmeRemoteControllerRequest.FromString,
                     response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             ),
-            'UpdateNVMfRemoteController': grpc.unary_unary_rpc_method_handler(
-                    servicer.UpdateNVMfRemoteController,
-                    request_deserializer=backend__nvme__tcp__pb2.UpdateNVMfRemoteControllerRequest.FromString,
-                    response_serializer=backend__nvme__tcp__pb2.NVMfRemoteController.SerializeToString,
+            'UpdateNvmeRemoteController': grpc.unary_unary_rpc_method_handler(
+                    servicer.UpdateNvmeRemoteController,
+                    request_deserializer=backend__nvme__tcp__pb2.UpdateNvmeRemoteControllerRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmeRemoteController.SerializeToString,
             ),
-            'ListNVMfRemoteControllers': grpc.unary_unary_rpc_method_handler(
-                    servicer.ListNVMfRemoteControllers,
-                    request_deserializer=backend__nvme__tcp__pb2.ListNVMfRemoteControllersRequest.FromString,
-                    response_serializer=backend__nvme__tcp__pb2.ListNVMfRemoteControllersResponse.SerializeToString,
+            'ListNvmeRemoteControllers': grpc.unary_unary_rpc_method_handler(
+                    servicer.ListNvmeRemoteControllers,
+                    request_deserializer=backend__nvme__tcp__pb2.ListNvmeRemoteControllersRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.ListNvmeRemoteControllersResponse.SerializeToString,
             ),
-            'GetNVMfRemoteController': grpc.unary_unary_rpc_method_handler(
-                    servicer.GetNVMfRemoteController,
-                    request_deserializer=backend__nvme__tcp__pb2.GetNVMfRemoteControllerRequest.FromString,
-                    response_serializer=backend__nvme__tcp__pb2.NVMfRemoteController.SerializeToString,
+            'GetNvmeRemoteController': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetNvmeRemoteController,
+                    request_deserializer=backend__nvme__tcp__pb2.GetNvmeRemoteControllerRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmeRemoteController.SerializeToString,
             ),
-            'NVMfRemoteControllerReset': grpc.unary_unary_rpc_method_handler(
-                    servicer.NVMfRemoteControllerReset,
-                    request_deserializer=backend__nvme__tcp__pb2.NVMfRemoteControllerResetRequest.FromString,
+            'NvmeRemoteControllerReset': grpc.unary_unary_rpc_method_handler(
+                    servicer.NvmeRemoteControllerReset,
+                    request_deserializer=backend__nvme__tcp__pb2.NvmeRemoteControllerResetRequest.FromString,
                     response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             ),
-            'NVMfRemoteControllerStats': grpc.unary_unary_rpc_method_handler(
-                    servicer.NVMfRemoteControllerStats,
-                    request_deserializer=backend__nvme__tcp__pb2.NVMfRemoteControllerStatsRequest.FromString,
-                    response_serializer=backend__nvme__tcp__pb2.NVMfRemoteControllerStatsResponse.SerializeToString,
+            'NvmeRemoteControllerStats': grpc.unary_unary_rpc_method_handler(
+                    servicer.NvmeRemoteControllerStats,
+                    request_deserializer=backend__nvme__tcp__pb2.NvmeRemoteControllerStatsRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmeRemoteControllerStatsResponse.SerializeToString,
+            ),
+            'ListNvmeRemoteNamespaces': grpc.unary_unary_rpc_method_handler(
+                    servicer.ListNvmeRemoteNamespaces,
+                    request_deserializer=backend__nvme__tcp__pb2.ListNvmeRemoteNamespacesRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.ListNvmeRemoteNamespacesResponse.SerializeToString,
+            ),
+            'CreateNvmePath': grpc.unary_unary_rpc_method_handler(
+                    servicer.CreateNvmePath,
+                    request_deserializer=backend__nvme__tcp__pb2.CreateNvmePathRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmePath.SerializeToString,
+            ),
+            'DeleteNvmePath': grpc.unary_unary_rpc_method_handler(
+                    servicer.DeleteNvmePath,
+                    request_deserializer=backend__nvme__tcp__pb2.DeleteNvmePathRequest.FromString,
+                    response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+            ),
+            'UpdateNvmePath': grpc.unary_unary_rpc_method_handler(
+                    servicer.UpdateNvmePath,
+                    request_deserializer=backend__nvme__tcp__pb2.UpdateNvmePathRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmePath.SerializeToString,
+            ),
+            'ListNvmePaths': grpc.unary_unary_rpc_method_handler(
+                    servicer.ListNvmePaths,
+                    request_deserializer=backend__nvme__tcp__pb2.ListNvmePathsRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.ListNvmePathsResponse.SerializeToString,
+            ),
+            'GetNvmePath': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetNvmePath,
+                    request_deserializer=backend__nvme__tcp__pb2.GetNvmePathRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmePath.SerializeToString,
+            ),
+            'NvmePathStats': grpc.unary_unary_rpc_method_handler(
+                    servicer.NvmePathStats,
+                    request_deserializer=backend__nvme__tcp__pb2.NvmePathStatsRequest.FromString,
+                    response_serializer=backend__nvme__tcp__pb2.NvmePathStatsResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'opi_api.storage.v1.NVMfRemoteControllerService', rpc_method_handlers)
+            'opi_api.storage.v1.NvmeRemoteControllerService', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
  # This class is part of an EXPERIMENTAL API.
-class NVMfRemoteControllerService(object):
+class NvmeRemoteControllerService(object):
     """Back End (network-facing) APIs. NVMe/TCP and NVMe/RoCEv2 protocols are covered by this service.
     """
 
     @staticmethod
-    def CreateNVMfRemoteController(request,
+    def CreateNvmeRemoteController(request,
             target,
             options=(),
             channel_credentials=None,
@@ -159,14 +271,14 @@ class NVMfRemoteControllerService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NVMfRemoteControllerService/CreateNVMfRemoteController',
-            backend__nvme__tcp__pb2.CreateNVMfRemoteControllerRequest.SerializeToString,
-            backend__nvme__tcp__pb2.NVMfRemoteController.FromString,
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/CreateNvmeRemoteController',
+            backend__nvme__tcp__pb2.CreateNvmeRemoteControllerRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmeRemoteController.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def DeleteNVMfRemoteController(request,
+    def DeleteNvmeRemoteController(request,
             target,
             options=(),
             channel_credentials=None,
@@ -176,14 +288,14 @@ class NVMfRemoteControllerService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NVMfRemoteControllerService/DeleteNVMfRemoteController',
-            backend__nvme__tcp__pb2.DeleteNVMfRemoteControllerRequest.SerializeToString,
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/DeleteNvmeRemoteController',
+            backend__nvme__tcp__pb2.DeleteNvmeRemoteControllerRequest.SerializeToString,
             google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def UpdateNVMfRemoteController(request,
+    def UpdateNvmeRemoteController(request,
             target,
             options=(),
             channel_credentials=None,
@@ -193,14 +305,14 @@ class NVMfRemoteControllerService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NVMfRemoteControllerService/UpdateNVMfRemoteController',
-            backend__nvme__tcp__pb2.UpdateNVMfRemoteControllerRequest.SerializeToString,
-            backend__nvme__tcp__pb2.NVMfRemoteController.FromString,
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/UpdateNvmeRemoteController',
+            backend__nvme__tcp__pb2.UpdateNvmeRemoteControllerRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmeRemoteController.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def ListNVMfRemoteControllers(request,
+    def ListNvmeRemoteControllers(request,
             target,
             options=(),
             channel_credentials=None,
@@ -210,14 +322,14 @@ class NVMfRemoteControllerService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NVMfRemoteControllerService/ListNVMfRemoteControllers',
-            backend__nvme__tcp__pb2.ListNVMfRemoteControllersRequest.SerializeToString,
-            backend__nvme__tcp__pb2.ListNVMfRemoteControllersResponse.FromString,
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/ListNvmeRemoteControllers',
+            backend__nvme__tcp__pb2.ListNvmeRemoteControllersRequest.SerializeToString,
+            backend__nvme__tcp__pb2.ListNvmeRemoteControllersResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def GetNVMfRemoteController(request,
+    def GetNvmeRemoteController(request,
             target,
             options=(),
             channel_credentials=None,
@@ -227,14 +339,14 @@ class NVMfRemoteControllerService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NVMfRemoteControllerService/GetNVMfRemoteController',
-            backend__nvme__tcp__pb2.GetNVMfRemoteControllerRequest.SerializeToString,
-            backend__nvme__tcp__pb2.NVMfRemoteController.FromString,
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/GetNvmeRemoteController',
+            backend__nvme__tcp__pb2.GetNvmeRemoteControllerRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmeRemoteController.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def NVMfRemoteControllerReset(request,
+    def NvmeRemoteControllerReset(request,
             target,
             options=(),
             channel_credentials=None,
@@ -244,14 +356,14 @@ class NVMfRemoteControllerService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NVMfRemoteControllerService/NVMfRemoteControllerReset',
-            backend__nvme__tcp__pb2.NVMfRemoteControllerResetRequest.SerializeToString,
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/NvmeRemoteControllerReset',
+            backend__nvme__tcp__pb2.NvmeRemoteControllerResetRequest.SerializeToString,
             google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def NVMfRemoteControllerStats(request,
+    def NvmeRemoteControllerStats(request,
             target,
             options=(),
             channel_credentials=None,
@@ -261,8 +373,127 @@ class NVMfRemoteControllerService(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NVMfRemoteControllerService/NVMfRemoteControllerStats',
-            backend__nvme__tcp__pb2.NVMfRemoteControllerStatsRequest.SerializeToString,
-            backend__nvme__tcp__pb2.NVMfRemoteControllerStatsResponse.FromString,
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/NvmeRemoteControllerStats',
+            backend__nvme__tcp__pb2.NvmeRemoteControllerStatsRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmeRemoteControllerStatsResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def ListNvmeRemoteNamespaces(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/ListNvmeRemoteNamespaces',
+            backend__nvme__tcp__pb2.ListNvmeRemoteNamespacesRequest.SerializeToString,
+            backend__nvme__tcp__pb2.ListNvmeRemoteNamespacesResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def CreateNvmePath(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/CreateNvmePath',
+            backend__nvme__tcp__pb2.CreateNvmePathRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmePath.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def DeleteNvmePath(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/DeleteNvmePath',
+            backend__nvme__tcp__pb2.DeleteNvmePathRequest.SerializeToString,
+            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def UpdateNvmePath(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/UpdateNvmePath',
+            backend__nvme__tcp__pb2.UpdateNvmePathRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmePath.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def ListNvmePaths(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/ListNvmePaths',
+            backend__nvme__tcp__pb2.ListNvmePathsRequest.SerializeToString,
+            backend__nvme__tcp__pb2.ListNvmePathsResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def GetNvmePath(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/GetNvmePath',
+            backend__nvme__tcp__pb2.GetNvmePathRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmePath.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def NvmePathStats(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/opi_api.storage.v1.NvmeRemoteControllerService/NvmePathStats',
+            backend__nvme__tcp__pb2.NvmePathStatsRequest.SerializeToString,
+            backend__nvme__tcp__pb2.NvmePathStatsResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)


### PR DESCRIPTION
Naming NVMf caused proto to force "nv_mf" syntax which is weird.
Unify the naming to Nvme format utilized throughout all API components.

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
